### PR TITLE
Bugfix/customization errors

### DIFF
--- a/frontend/src/renderer/components/select/RenderSelectOption.tsx
+++ b/frontend/src/renderer/components/select/RenderSelectOption.tsx
@@ -1,0 +1,35 @@
+import { Group, Tooltip } from '@mantine/core';
+import { OptionWithTooltip } from '../../types/components/select';
+import { IconCheck, IconHelpCircle } from '@tabler/icons-react';
+
+const iconProps = {
+  stroke: 1.5,
+  color: 'currentColor',
+  opacity: 0.6,
+  size: 20,
+};
+
+interface RenderSelectOptionProps {
+  option: OptionWithTooltip;
+  checked: boolean;
+}
+
+export const RenderSelectOption = ({
+  option,
+  checked,
+}: RenderSelectOptionProps) => {
+  return (
+    <Group justify="space-between" w="100%">
+      <Group gap="xs">
+        {checked && (
+          <IconCheck style={{ marginInlineStart: 'auto' }} {...iconProps} />
+        )}
+        {option.value}
+      </Group>
+
+      <Tooltip label={option.tooltip} openDelay={300} position="bottom-end">
+        {<IconHelpCircle {...iconProps} />}
+      </Tooltip>
+    </Group>
+  );
+};

--- a/frontend/src/renderer/components/select/index.ts
+++ b/frontend/src/renderer/components/select/index.ts
@@ -1,0 +1,1 @@
+export * from './RenderSelectOption';

--- a/frontend/src/renderer/pages/visualization/DataplotCustomization.tsx
+++ b/frontend/src/renderer/pages/visualization/DataplotCustomization.tsx
@@ -48,6 +48,7 @@ const Customization = ({
     component: JSX.Element;
     icon?: JSX.Element;
     disabled?: boolean;
+    tooltip?: string;
   };
   const accordionItems: accordionItemsType[] = [
     {
@@ -87,7 +88,11 @@ const Customization = ({
         />
       ),
       icon: (
-        <ActionIcon variant="filled" component="span">
+        <ActionIcon
+          variant="filled"
+          component="span"
+          disabled={customizedDataGrid.coordinates.length < 2}
+        >
           <svg width="50" height="50" viewBox="0 0 50 50">
             <rect x="0" y="0" width="15" height="15" fill="#440154" />
             <rect x="17" y="0" width="15" height="15" fill="#31688e" />
@@ -103,6 +108,8 @@ const Customization = ({
           </svg>
         </ActionIcon>
       ),
+      disabled: customizedDataGrid.coordinates.length < 2,
+      tooltip: "This grid can't display heatmap",
     },
     {
       value: 'Axis range',
@@ -132,7 +139,11 @@ const Customization = ({
   const items = accordionItems.map((item) => (
     <Tooltip
       key={item.value}
-      label={item?.disabled ? 'This feature will be available soon' : ''}
+      label={
+        item?.disabled
+          ? item?.tooltip || 'This feature will be available soon'
+          : ''
+      }
       position="bottom-start"
       opened={item?.disabled ? null : false}
     >

--- a/frontend/src/renderer/pages/visualization/DataplotCustomization.tsx
+++ b/frontend/src/renderer/pages/visualization/DataplotCustomization.tsx
@@ -223,12 +223,12 @@ export const DataplotCustomization = () => {
     // Get child elements from the legend
     const legends = customContainer.querySelectorAll<SVGGElement>('g.layers');
 
+    const updatedPlotColors = JSON.parse(
+      JSON.stringify(customizedDataGrid),
+    ) as DataGridPlot;
     if (legends?.length) {
+      // When we have a color legend (so several plots)
       let plotIndex = 0;
-      const updatedPlotColors = JSON.parse(
-        JSON.stringify(customizedDataGrid),
-      ) as DataGridPlot;
-
       let shouldUpdateColors = false;
       for (const plot of updatedPlotColors.plot) {
         // Get from DOM & set color in plot.line for each plots
@@ -255,9 +255,13 @@ export const DataplotCustomization = () => {
       if (!shouldUpdateColors) {
         return;
       }
-
-      setCustomizedDataGrid(updatedPlotColors);
+    } else if (updatedPlotColors.plot.length === 1) {
+      // When we have only one plot, thee is no legend so we set manualy to the first plotly color
+      updatedPlotColors.plot[0].line = {
+        color: 'rgb(31, 119, 180)',
+      } as PlotLine;
     }
+    setCustomizedDataGrid(updatedPlotColors);
   };
 
   useEffect(() => {

--- a/frontend/src/renderer/pages/visualization/customizableElements/Customize1DPlot.tsx
+++ b/frontend/src/renderer/pages/visualization/customizableElements/Customize1DPlot.tsx
@@ -71,9 +71,10 @@ export const Customize1DPlot = ({
       JSON.stringify(customizedDataGrid),
     ) as DataGridPlot;
 
-    updatedDataPlot.plot.find(
+    const plotToUpdate = updatedDataPlot.plot.find(
       (plot) => plot.name === selectedPlot.name,
-    ).line.shape = newShape;
+    );
+    plotToUpdate.line = { ...plotToUpdate?.line, shape: newShape };
 
     setCustomizedDataGrid({
       ...customizedDataGrid,

--- a/frontend/src/renderer/pages/visualization/customizableElements/Customize1DPlot.tsx
+++ b/frontend/src/renderer/pages/visualization/customizableElements/Customize1DPlot.tsx
@@ -123,7 +123,10 @@ export const Customize1DPlot = ({
         label="Plot shape"
         description="Customize the shape"
         placeholder="Customize the shape"
-        data={['linear', 'hv']}
+        data={[
+          { value: 'linear', label: 'linear' },
+          { value: 'hv', label: 'hv (Horizontal-Vertical)' },
+        ]}
         value={selectedPlot?.line?.shape || 'linear'}
         onChange={(value) => updatePlotShape(value)}
         maw={200}

--- a/frontend/src/renderer/pages/visualization/customizableElements/CustomizeDownsampling.tsx
+++ b/frontend/src/renderer/pages/visualization/customizableElements/CustomizeDownsampling.tsx
@@ -12,6 +12,8 @@ import {
 import { showNotification } from '@mantine/notifications';
 import { Button, Group, NumberInput, Select, Stack } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
+import { OptionWithTooltip } from '../../../types/components/select';
+import { RenderSelectOption } from '../../../components/select';
 
 interface CustomizeDownsamplingProps {
   customizedDataGrid: DataGridPlot;
@@ -21,7 +23,9 @@ export const CustomizeDownsampling = ({
   customizedDataGrid,
   setCustomizedDataGrid,
 }: CustomizeDownsamplingProps) => {
-  const [downsamplingList, setDownsamplingList] = useState<string[]>([]);
+  const [downsamplingList, setDownsamplingList] = useState<OptionWithTooltip[]>(
+    [],
+  );
   const [downsamplingSize, setDownsamplingSize] = useState<number>(1000);
   const [downsamplingMethod, setDownsamplingMethod] = useState<string | null>(
     null,
@@ -132,9 +136,13 @@ export const CustomizeDownsampling = ({
   useEffect(() => {
     const getDownsamplingList = async () => {
       const methodsRes = await fetchDownsamplingMethods();
-      setDownsamplingList(
-        methodsRes.downsampling_methods.map((method) => method.name),
+      const options: OptionWithTooltip[] = methodsRes.downsampling_methods.map(
+        (item) => ({
+          value: item.name,
+          tooltip: item.description,
+        }),
       );
+      setDownsamplingList(options);
     };
     getDownsamplingList();
   }, []);
@@ -161,8 +169,19 @@ export const CustomizeDownsampling = ({
           description="Select the method"
           placeholder="Select the method"
           value={downsamplingMethod || 'None'}
-          data={downsamplingList}
+          data={downsamplingList.map((meth) => meth.value)}
           onChange={setDownsamplingMethod}
+          renderOption={(option) => {
+            const selectedOption = downsamplingList.find(
+              (meth) => option.option.value === meth.value,
+            );
+            return (
+              <RenderSelectOption
+                option={selectedOption}
+                checked={option.checked}
+              />
+            );
+          }}
           w="45%"
           maw={200}
         />

--- a/frontend/src/renderer/types/components/select.ts
+++ b/frontend/src/renderer/types/components/select.ts
@@ -1,0 +1,4 @@
+export type OptionWithTooltip = {
+  value: string;
+  tooltip: string;
+};


### PR DESCRIPTION
This PR resolve issue #6 and contains:

- Fix the crash when selecting HV
- Add tooltips to describe downsampling method + update label of HV (horizontal-vertical)
- Fix a crash in heatmap customization by disabling it when it couldn't be displayed (when we don't have enough coordinates)