### PR TITLE
fix: get right x title at loading

### DIFF
--- a/frontend/src/renderer/pages/visualization/customizableElements/CustomizeGlobal.tsx
+++ b/frontend/src/renderer/pages/visualization/customizableElements/CustomizeGlobal.tsx
@@ -70,7 +70,11 @@ export const CustomizeGlobal = ({
           description="Customize the type of x axis"
           placeholder="Customize the type of x axis"
           data={getSelectableData(typeOfXData)}
-          value={customizedDataGrid?.xAxisData?.type}
+          value={
+            customizedDataGrid?.xAxisData?.type ||
+            getSelectableData(typeOfXData).find((el) => el.disabled === false)
+              .value
+          }
           onChange={(value) =>
             value &&
             setCustomizedDataGrid({
@@ -85,7 +89,11 @@ export const CustomizeGlobal = ({
           description="Customize the type of y axis"
           placeholder="Customize the type of y axis"
           data={getSelectableData(typeOfYData)}
-          value={customizedDataGrid?.yAxisData?.type || 'linear'}
+          value={
+            customizedDataGrid?.yAxisData?.type ||
+            getSelectableData(typeOfYData).find((el) => el.disabled === false)
+              .value
+          }
           onChange={(value) =>
             value &&
             setCustomizedDataGrid({
@@ -101,7 +109,12 @@ export const CustomizeGlobal = ({
             description="Customize the type of y2 axis"
             placeholder="Customize the type of y2 axis"
             data={getSelectableData(typeOfY2Data)}
-            value={customizedDataGrid?.y2AxisData?.type || 'linear'}
+            value={
+              customizedDataGrid?.y2AxisData?.type ||
+              getSelectableData(typeOfY2Data).find(
+                (el) => el.disabled === false,
+              ).value
+            }
             onChange={(value) =>
               value &&
               setCustomizedDataGrid({

--- a/frontend/src/renderer/utils/plot.ts
+++ b/frontend/src/renderer/utils/plot.ts
@@ -780,7 +780,7 @@ export async function plotNodeUriLoaded(
         const updatedXAxisData: Axis = dataGrid.xAxisData;
 
         const updatedPlot: DataPlotly[] = [];
-        for (const plot of dataGrid.plot) {
+        for (const [index, plot] of dataGrid.plot.entries()) {
           if (!plot.nodeUri) {
             updatedPlot.push(plot);
             continue;
@@ -855,6 +855,14 @@ export async function plotNodeUriLoaded(
                 lastField,
                 matchingCoord.valueIndex,
               );
+
+              if (response.data.coordinates.length > 0 && index === 0) {
+                // Update x axis informations to plot right x axis title in a saved file with transposition (useless if transposition will be restored at load)
+                updatedXAxisData.name = response.data.coordinates[0].name;
+                updatedXAxisData.unit = response.data.coordinates[0].unit;
+                updatedXAxisData.path = response.data.coordinates[0].path;
+                delete updatedXAxisData.type;
+              }
 
               matchingCoordList.push(matchingCoord);
             }


### PR DESCRIPTION
This PR contains:

- Get correct title in x axis when loading from a configuration a transposed plot
- Always fill x type (customization > Global > type of x axis)