### PR TITLE
fix version issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,7 @@ venv4linting/
 *.swo
 
 # SCM setuptools
-backend/ibex/version.py
+backend/ibex/_version.py
 
 # Saxon symlink or downloaded file
 saxon*.jar

--- a/backend/ibex/__init__.py
+++ b/backend/ibex/__init__.py
@@ -3,10 +3,10 @@
 import logging
 from ibex.setup_logging import connect_formatter
 
-from . import _version
+from ._version import version as version
+from ._version import __version__ as __version__
+from ._version import version_tuple as version_tuple
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 connect_formatter(logger)
-
-__version__ = _version.get_versions()["version"]


### PR DESCRIPTION
```
$ python
Python 3.11.5 (main, Jul 30 2025, 19:17:56) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ibex
>>> ibex.version
'0.1.1.dev73'
>>> ibex.__version__
'0.1.1.dev73'
>>> ibex.version_tuple
(0, 1, 1, 'dev73')
>>> 


```