### PR TITLE
delete all uris: don't display 0

### DIFF
--- a/frontend/src/renderer/pages/visualization/VisualizationURIModal.tsx
+++ b/frontend/src/renderer/pages/visualization/VisualizationURIModal.tsx
@@ -222,8 +222,8 @@ export const VisualizationURIModal = ({
       <Table.Th>Select</Table.Th>
       <Table.Th>Name</Table.Th>
       <Table.Th>URI</Table.Th>
-      <Table.Td>
-        {dataDbEntries.length && (
+      {dataDbEntries.length ? (
+        <Table.Th>
           <Tooltip label="Delete all URIs" openDelay={300}>
             <ActionIcon
               variant="filled"
@@ -238,8 +238,8 @@ export const VisualizationURIModal = ({
               />
             </ActionIcon>
           </Tooltip>
-        )}
-      </Table.Td>
+        </Table.Th>
+      ) : undefined}
     </Table.Tr>
   );
 


### PR DESCRIPTION
This fix resolve the '0' displayed whereas it shouldn't when the button to delete all URIs is hide. 

It Closes #40 if @deepakmaroo confirm that there is no more bugs seen in #40.