### PR TITLE
handle coordinate dependencies in correct order

### DIFF
--- a/frontend/src/renderer/types/plot.ts
+++ b/frontend/src/renderer/types/plot.ts
@@ -32,7 +32,7 @@ export interface BaseCoordinates {
 export interface Coordinates extends BaseCoordinates {
   name: string;
   shape: number[] | 'irregular';
-  coordinates: string[];
+  coord_dependencies: string[];
   data: AxisData;
   unit?: string;
 }

--- a/frontend/src/renderer/utils/matrix.ts
+++ b/frontend/src/renderer/utils/matrix.ts
@@ -34,7 +34,7 @@ export const getArrayValueFromDependance = (
   const wantedCoordinate: Coordinates = coordinates.find(
     (coord) => coord.axeIndex === axeIndexWanted,
   );
-  if (!wantedCoordinate.coordinates.length) {
+  if (!wantedCoordinate.coord_dependencies.length) {
     // get first array value when having no dependance
     return getFirstArrayValueFromShape(
       wantedCoordinate.data,
@@ -43,7 +43,7 @@ export const getArrayValueFromDependance = (
   }
 
   // get sorted valueIndex list (sorted by shape length) to access to data matrix
-  const dependances = wantedCoordinate.coordinates;
+  const dependances = JSON.parse(JSON.stringify(wantedCoordinate.coord_dependencies)).reverse();
   const sortedIndexValueDependances: number[] = [];
   for (const dependance of dependances) {
     const coordDep = coordinates.find(

--- a/frontend/src/renderer/utils/plot.ts
+++ b/frontend/src/renderer/utils/plot.ts
@@ -738,7 +738,7 @@ export function formatConfigBeforeLoadingURIs(
                 ...coord,
                 name: '',
                 shape: [],
-                coordinates: [],
+                coord_dependencies: [],
                 data: [],
               };
             })
@@ -788,7 +788,7 @@ function formatCoordinates(
         name: coordinate.name,
         shape: coordinate.shape,
         downsampled_shape: coordinate.downsampled_shape,
-        coordinates: coordinate.coordinates,
+        coord_dependencies: coordinate.coordinates,
         data: coordinate.value,
         valueIndex: valueIndex,
         path:
@@ -888,7 +888,7 @@ export async function plotNodeUriLoaded(
               matchingCoord.path = getDefaultUri(responseCoordinates.path);
               matchingCoord.unit = responseCoordinates.unit || '';
               matchingCoord.shape = responseCoordinates.downsampled_shape;
-              matchingCoord.coordinates = responseCoordinates.coordinates;
+              matchingCoord.coord_dependencies = responseCoordinates.coordinates;
 
               //* Update the target - yPath - axis data with the index
               matchingCoord.target = updateIndexFieldName(
@@ -1887,7 +1887,7 @@ export async function applyRangeInCoord(
     }
 
     const dependencyIndex = (
-      JSON.parse(JSON.stringify(coordDependencie.coordinates)) as string[]
+      JSON.parse(JSON.stringify(coordDependencie.coord_dependencies)) as string[]
     )
       .reverse() // We reverse dependencies to get dependency index in the order of the matrix
       .findIndex((dep) => dep === coordinate.name);


### PR DESCRIPTION
This PR Closes #48 by fixing the way I handle coordinate dependencies to get values.

It also fixes the second bug occuring in #47 