### PR TITLE
fix an issue with the plot mode selection

### DIFF
--- a/frontend/src/renderer/components/grid/GridLayoutPlot.tsx
+++ b/frontend/src/renderer/components/grid/GridLayoutPlot.tsx
@@ -12,7 +12,6 @@ import { Center, Container, Text } from '@mantine/core';
 import { SimplePlotly, Heatmap2D } from '../plot';
 import { useIbexStore } from '../../stores';
 import {
-  containsFloat,
   getArrayValueFromDependance,
   getErrorYVectors,
   getLastIndexedField,
@@ -201,40 +200,9 @@ export const GridLayoutPlot = ({
     }
   }, [data.plot]);
 
-  const updateSelectedPlotMode = (is3DView: boolean, active: Configuration) => {
-    const updatedDataPlot: DataGridPlot[] = JSON.parse(
-      JSON.stringify(active.dataPlot),
-    );
-    const selectedDataPlot = updatedDataPlot.find(
-      (dataPlot) => dataPlot.i === data.i,
-    );
-    if (selectedDataPlot?.selectedPlotMode) {
-      selectedDataPlot.selectedPlotMode = is3DView ? 'Heatmap' : '1D';
-    } else {
-      selectedDataPlot.selectedPlotMode =
-        data.coordinates.length >= 2 &&
-        containsFloat(
-          data.coordinates.find((coord) => coord.axeIndex === 1)?.data,
-        )
-          ? 'Heatmap'
-          : '1D';
-    }
-
-    const updatedActive: Configuration = {
-      ...active,
-      dataPlot: updatedDataPlot,
-    };
-    updatedConfiguration(updatedActive);
-  };
-
   useEffect(() => {
-    if ((data.selectedPlotMode === 'Heatmap') === is3DView) {
-      // Prevent from triggering updateSelectedPlotMode when initialize is3DView
-      return;
-    }
-
-    updateSelectedPlotMode(is3DView, active);
-  }, [is3DView]);
+    setIs3DView(data?.selectedPlotMode === 'Heatmap' ? true : false);
+  }, [data.selectedPlotMode]);
 
   /**
    * Handle the delete grid event
@@ -378,7 +346,6 @@ export const GridLayoutPlot = ({
           handleCustomization={handleCustomization}
           handleDeleteGrid={handleDeleteGrid}
           is3DView={is3DView}
-          setIs3DView={setIs3DView}
           active3DTab={active3DTab}
           setActive3DTab={setActive3DTab}
         />

--- a/frontend/src/renderer/components/grid/HoverButtons.tsx
+++ b/frontend/src/renderer/components/grid/HoverButtons.tsx
@@ -18,7 +18,11 @@ import {
 } from '@tabler/icons-react';
 import { useHover } from '@mantine/hooks';
 import { Configuration, DataGridPlot } from '../../types';
-import { applyRange, fetchErrorBandsInConfig } from '../../utils';
+import {
+  applyRange,
+  containsFloat,
+  fetchErrorBandsInConfig,
+} from '../../utils';
 import { useIbexStore } from '../../stores';
 
 interface HoverButtonsProps {
@@ -29,7 +33,6 @@ interface HoverButtonsProps {
   handleCustomization: (id: string) => void;
   handleDeleteGrid: (id: string) => void;
   is3DView: boolean;
-  setIs3DView: React.Dispatch<React.SetStateAction<boolean>>;
   active3DTab: string;
   setActive3DTab: React.Dispatch<React.SetStateAction<string>>;
 }
@@ -43,7 +46,6 @@ export const HoverButtons = React.memo(
     handleCustomization,
     handleDeleteGrid,
     is3DView,
-    setIs3DView,
     active3DTab,
     setActive3DTab,
   }: HoverButtonsProps) => {
@@ -159,6 +161,35 @@ export const HoverButtons = React.memo(
       updateErrorBands();
     }, [data.displayErrorBand]);
 
+    const updateSelectedPlotMode = (
+      is3DView: boolean,
+      active: Configuration,
+    ) => {
+      const updatedDataPlot: DataGridPlot[] = JSON.parse(
+        JSON.stringify(active.dataPlot),
+      );
+      const selectedDataPlot = updatedDataPlot.find(
+        (dataPlot) => dataPlot.i === data.i,
+      );
+      if (selectedDataPlot?.selectedPlotMode) {
+        selectedDataPlot.selectedPlotMode = is3DView ? 'Heatmap' : '1D';
+      } else {
+        selectedDataPlot.selectedPlotMode =
+          data.coordinates.length >= 2 &&
+          containsFloat(
+            data.coordinates.find((coord) => coord.axeIndex === 1)?.data,
+          )
+            ? 'Heatmap'
+            : '1D';
+      }
+
+      const updatedActive: Configuration = {
+        ...active,
+        dataPlot: updatedDataPlot,
+      };
+      updatedConfiguration(updatedActive);
+    };
+
     return (
       <div ref={hoverRef} className={classes.containerButton}>
         <Group justify="space-between" h={'100%'}>
@@ -215,7 +246,12 @@ export const HoverButtons = React.memo(
                   <ActionIcon
                     variant="filled"
                     aria-label="Toggle 1D/Heatmap view"
-                    onClick={() => setIs3DView((prev) => !prev)}
+                    onClick={() =>
+                      updateSelectedPlotMode(
+                        !(data.selectedPlotMode === 'Heatmap'),
+                        active,
+                      )
+                    }
                     className={classes.actionButton}
                   >
                     {is3DView ? <Text fw="bold">1D</Text> : heatmapLogo}
@@ -262,11 +298,7 @@ export const HoverButtons = React.memo(
               )}
 
               <Tooltip
-                label={
-                  data.isEditing
-                    ? 'Validate/Close editing the grid'
-                    : 'Open editing the grid'
-                }
+                label={data.isEditing ? 'Save the edition' : 'Edit the grid'}
               >
                 <ActionIcon
                   variant="filled"

--- a/frontend/src/renderer/utils/matrix.ts
+++ b/frontend/src/renderer/utils/matrix.ts
@@ -43,7 +43,9 @@ export const getArrayValueFromDependance = (
   }
 
   // get sorted valueIndex list (sorted by shape length) to access to data matrix
-  const dependances = JSON.parse(JSON.stringify(wantedCoordinate.coord_dependencies)).reverse();
+  const dependances = JSON.parse(
+    JSON.stringify(wantedCoordinate.coord_dependencies),
+  ).reverse();
   const sortedIndexValueDependances: number[] = [];
   for (const dependance of dependances) {
     const coordDep = coordinates.find(

--- a/frontend/src/renderer/utils/plot.ts
+++ b/frontend/src/renderer/utils/plot.ts
@@ -896,7 +896,8 @@ export async function plotNodeUriLoaded(
               matchingCoord.path = getDefaultUri(responseCoordinates.path);
               matchingCoord.unit = responseCoordinates.unit || '';
               matchingCoord.shape = responseCoordinates.downsampled_shape;
-              matchingCoord.coord_dependencies = responseCoordinates.coordinates;
+              matchingCoord.coord_dependencies =
+                responseCoordinates.coordinates;
 
               //* Update the target - yPath - axis data with the index
               matchingCoord.target = updateIndexFieldName(
@@ -1895,7 +1896,9 @@ export async function applyRangeInCoord(
     }
 
     const dependencyIndex = (
-      JSON.parse(JSON.stringify(coordDependencie.coord_dependencies)) as string[]
+      JSON.parse(
+        JSON.stringify(coordDependencie.coord_dependencies),
+      ) as string[]
     )
       .reverse() // We reverse dependencies to get dependency index in the order of the matrix
       .findIndex((dep) => dep === coordinate.name);


### PR DESCRIPTION
This PR aims to fix an issue with the plot mode selection.

It occured in a specific scenario: when switching modes ("1D" or "heatmap") while edit mode was enabled, and then clicking on the  metadata or custom button.