### PR TITLE
Feature/interpolation without new values

### DIFF
--- a/backend/ibex/core/ibex_service.py
+++ b/backend/ibex/core/ibex_service.py
@@ -116,7 +116,11 @@ def get_multiple_node_data(uri: str) -> dict:
 
 
 def get_plot_data(
-    uri: str, interpolate_over: List[str] | None, downsampling_method: str | None, downsampled_size: int
+    uri: str,
+    interpolate_over: List[str] | None,
+    interpolation_method: str | None,
+    downsampling_method: str | None,
+    downsampled_size: int,
 ) -> dict:
     uri_obj = IMAS_URI(uri)
     return data_source.get_plot_data(
@@ -125,6 +129,7 @@ def get_plot_data(
         node_path=uri_obj.node_path,
         occurrence=uri_obj.occurrence,
         interpolate_over=interpolate_over,
+        interpolation_method=interpolation_method,
         downsampling_method=downsampling_method,
         downsampled_size=downsampled_size,
     )

--- a/backend/ibex/core/ibex_service.py
+++ b/backend/ibex/core/ibex_service.py
@@ -69,7 +69,7 @@ def get_node_info(uri: str, recursive: bool = False, show_error_bars: bool = Fal
     )
 
 
-def get_data(uri: str, downsampling_method: str | None, downsampled_size: int, range: List[int]) -> dict:
+def get_data(uri: str, downsampling_method: str | None, downsampled_size: int) -> dict:
     uri_obj = IMAS_URI(uri)
     return data_source.get_data(
         uri=uri_obj.uri_entry_identifiers,
@@ -78,7 +78,6 @@ def get_data(uri: str, downsampling_method: str | None, downsampled_size: int, r
         occurrence=uri_obj.occurrence,
         downsampling_method=downsampling_method,
         downsampled_size=downsampled_size,
-        range=range,
     )
 
 

--- a/backend/ibex/data_source/data_source_interface.py
+++ b/backend/ibex/data_source/data_source_interface.py
@@ -56,7 +56,7 @@ class DataSourceInterface(ABC):
         ...
 
     @abstractmethod
-    def get_data(self, uri: str, ids: str, node_path: str, occurrence: int = 0, range: List[int] | None = None) -> dict:
+    def get_data(self, uri: str, ids: str, node_path: str, occurrence: int = 0, downsampling_method: str | None = None, downsampled_size: int = 1000,) -> dict:
         """
         Returns data extracted from IDS, converted into dictionary
 
@@ -64,7 +64,8 @@ class DataSourceInterface(ABC):
         :param ids: name of ids e.g. core_profiles
         :param node_path: path to ids node e.g. ids_properties/version_put
         :param occurrence: ids occurrence number
-        :param range:
+        :param downsampling_method: method to be used during downsampling process
+        :param downsampled_size: target size for downsampling
         :return: dictionary {'value':<node_value>}, where <node_value> represents data extracted from IDS node
         """
         ...
@@ -111,5 +112,31 @@ class DataSourceInterface(ABC):
         :param database: searched database name: default(None)
         :param version: searched AL major version:
         :return: dictionary {'entries': [<uri1>, <uri2>, ...]}
+        """
+        ...
+
+    def get_plot_data(
+        self,
+        uri: str,
+        ids: str,
+        node_path: str,
+        occurrence: int = 0,
+        interpolate_over: List[str] | None = None,
+        interpolation_method: str | None = None,
+        downsampling_method: str | None = None,
+        downsampled_size: int = 1000,
+    ) -> dict:
+        """
+        Returns all data used to plot selected quantity. Result contains data values, metadata and coordinates.
+
+        :param uri: imas URI
+        :param ids: name of ids e.g. core_profiles
+        :param node_path: path to ids node e.g. ids_properties/version_put
+        :param occurrence: ids occurrence number
+        :param interpolate_over: list of uris used in interpolation
+        :param interpolation_method: method to be used in data interpolation; one from scipy.interpolate.RegularGridInterpolator or 'exact_value'
+        :param downsampling_method: one of the downsampling metods returend by :func:`~ibex.endpoints.info.downsampling_methods` endpoint, or None
+        :param downsampled_size: target size of downsampled data
+        :return: Dictionary containing data values, metadata and coordinates.
         """
         ...

--- a/backend/ibex/data_source/data_source_interface.py
+++ b/backend/ibex/data_source/data_source_interface.py
@@ -56,7 +56,15 @@ class DataSourceInterface(ABC):
         ...
 
     @abstractmethod
-    def get_data(self, uri: str, ids: str, node_path: str, occurrence: int = 0, downsampling_method: str | None = None, downsampled_size: int = 1000,) -> dict:
+    def get_data(
+        self,
+        uri: str,
+        ids: str,
+        node_path: str,
+        occurrence: int = 0,
+        downsampling_method: str | None = None,
+        downsampled_size: int = 1000,
+    ) -> dict:
         """
         Returns data extracted from IDS, converted into dictionary
 

--- a/backend/ibex/data_source/imas_python_source.py
+++ b/backend/ibex/data_source/imas_python_source.py
@@ -40,7 +40,8 @@ from ibex.core.utils import downsample_data, transform_2D_data, find_first_value
 from ibex.core.utils import IMAS_URI
 from ibex.data_source.imas_python_source_utils import (
     convert_ids_data_into_numpy_array,
-    resample_data,
+    resample_data_with_interpolation,
+    resample_data_without_interpolation,
     pad_to_rectangular,
     flatten,
     expand,
@@ -598,6 +599,7 @@ class IMASPythonSource(DataSourceInterface):
         node_path: str,
         occurrence: int = 0,
         interpolate_over: List[str] | None = None,
+        interpolation_method: str | None = None,
         downsampling_method: str | None = None,
         downsampled_size: int = 1000,
     ):
@@ -609,6 +611,7 @@ class IMASPythonSource(DataSourceInterface):
         :param node_path: path to ids node e.g. ids_properties/version_put
         :param occurrence: ids occurrence number
         :param interpolate_over: list of uris used in interpolation
+        :param interpolation_method: method to be used in data interpolation; one from scipy.interpolate.RegularGridInterpolator or 'exact_value'
         :param downsampling_method: one of the downsampling metods returend by :func:`~ibex.endpoints.info.downsampling_methods` endpoint, or None
         :param downsampled_size: target size of downsampled data
         :return: Dictionary containing data values, metadata and coordinates.
@@ -841,9 +844,19 @@ class IMASPythonSource(DataSourceInterface):
 
                 # === make data vector rectangular ===
                 data_to_be_returned = pad_to_rectangular(data_to_be_returned)
-                data_to_be_returned = resample_data(
-                    tuple(original_coord_values), data_to_be_returned, tuple(common_coords_values)
-                )
+
+                # === run interpolation ===
+                if interpolation_method == "exact_value":
+                    data_to_be_returned = resample_data_without_interpolation(
+                        tuple(original_coord_values), data_to_be_returned, tuple(common_coords_values)
+                    )
+                else:
+                    data_to_be_returned = resample_data_with_interpolation(
+                        tuple(original_coord_values),
+                        data_to_be_returned,
+                        tuple(common_coords_values),
+                        interpolation_method=interpolation_method,
+                    )
 
                 new_coordinate_shapes = calculate_coordinate_shapes(
                     list(np.asarray(data_to_be_returned).shape),

--- a/backend/ibex/data_source/imas_python_source.py
+++ b/backend/ibex/data_source/imas_python_source.py
@@ -393,7 +393,6 @@ class IMASPythonSource(DataSourceInterface):
         occurrence: int = 0,
         downsampling_method: str | None = None,
         downsampled_size: int = 1000,
-        range: List[int] | None = None,
     ) -> dict:
         """
         Returns data extracted from IDS, converted into dictionary
@@ -402,7 +401,8 @@ class IMASPythonSource(DataSourceInterface):
         :param ids: name of ids e.g. core_profiles
         :param node_path: path to ids node e.g. ids_properties/version_put
         :param occurrence: ids occurrence number
-        :param range:
+        :param downsampling_method: method to be used during downsampling process
+        :param downsampled_size: target size for downsampling
         :return: dictionary {'value':<node_value>}, where <node_value> represents data extracted from IDS node
         """
 
@@ -602,7 +602,7 @@ class IMASPythonSource(DataSourceInterface):
         interpolation_method: str | None = None,
         downsampling_method: str | None = None,
         downsampled_size: int = 1000,
-    ):
+    ) -> dict:
         """
         Returns all data used to plot selected quantity. Result contains data values, metadata and coordinates.
 

--- a/backend/ibex/data_source/imas_python_source.py
+++ b/backend/ibex/data_source/imas_python_source.py
@@ -846,7 +846,7 @@ class IMASPythonSource(DataSourceInterface):
                 data_to_be_returned = pad_to_rectangular(data_to_be_returned)
 
                 # === run interpolation ===
-                if interpolation_method == "exact_value":
+                if interpolation_method == "exact_value" or not interpolation_method:
                     data_to_be_returned = resample_data_without_interpolation(
                         tuple(original_coord_values), data_to_be_returned, tuple(common_coords_values)
                     )

--- a/backend/ibex/data_source/imas_python_source_utils.py
+++ b/backend/ibex/data_source/imas_python_source_utils.py
@@ -126,7 +126,9 @@ def pad_to_rectangular(lst):
     return arr
 
 
-def resample_data(original_coords: list, data: list, target_coords: list):
+def resample_data_with_interpolation(
+    original_coords: list, data: list, target_coords: list, interpolation_method: str | None = None
+):
     """
     Resamples data onto new set of coordinates.
     :param original_coords: List of original data coordinates.
@@ -134,7 +136,9 @@ def resample_data(original_coords: list, data: list, target_coords: list):
     :param target_coords: List of target coordinates.
     :return: Resampled data array.
     """
-    interpolator = RegularGridInterpolator(original_coords, data, bounds_error=False)
+    if not interpolation_method:
+        interpolation_method = "linear"
+    interpolator = RegularGridInterpolator(original_coords, data, bounds_error=False, method=interpolation_method)
 
     # build mesh grid (manipulate coordinates to be list of coordinates e.g. [[x1,y1,z1,h1...], [x2,y2,z2,h3...]])
     mesh = np.meshgrid(*target_coords, indexing="ij")
@@ -144,6 +148,44 @@ def resample_data(original_coords: list, data: list, target_coords: list):
 
     # revert mesh shape
     result = result.reshape([len(c) for c in target_coords])
+
+    return result
+
+
+def resample_data_without_interpolation(original_coords, data, target_coords):
+    """
+    Fast exact resampling using dictionaries.
+    Best for large grids / many dimensions.
+    """
+
+    # Create output array filled with NaN
+    output_shape = []
+    for target in target_coords:
+        output_shape.append(len(target))
+
+    result = np.full(output_shape, np.nan, dtype=float)
+
+    # Build target indices for each axis
+    target_indices = []
+
+    for orig, target in zip(original_coords, target_coords):
+        # Build dictionary: coordinate -> target index
+        lookup = {}
+        for i, value in enumerate(target):
+            lookup[value] = i
+
+        axis_indices = []
+
+        for value in orig:
+            axis_indices.append(lookup[value])
+
+        target_indices.append(axis_indices)
+
+    # Create mesh
+    mesh = np.meshgrid(*target_indices, indexing="ij")
+
+    # Copy data
+    result[tuple(mesh)] = data
 
     return result
 

--- a/backend/ibex/data_source/imas_python_source_utils.py
+++ b/backend/ibex/data_source/imas_python_source_utils.py
@@ -3,6 +3,7 @@ from functools import reduce
 import numpy as np
 from imas.ids_primitive import IDSNumericArray
 from scipy.interpolate import RegularGridInterpolator
+from ibex.data_source.exception import InvalidParametersException
 
 
 def union_arrays(data: list):
@@ -138,7 +139,11 @@ def resample_data_with_interpolation(
     """
     if not interpolation_method:
         interpolation_method = "linear"
-    interpolator = RegularGridInterpolator(original_coords, data, bounds_error=False, method=interpolation_method)
+    try:
+        interpolator = RegularGridInterpolator(original_coords, data, bounds_error=False, method=interpolation_method)
+    except ValueError as e:
+        message = f"Invalid parameter passed to interpolator: {e}"
+        raise InvalidParametersException(message) from None
 
     # build mesh grid (manipulate coordinates to be list of coordinates e.g. [[x1,y1,z1,h1...], [x2,y2,z2,h3...]])
     mesh = np.meshgrid(*target_coords, indexing="ij")

--- a/backend/ibex/endpoints/data.py
+++ b/backend/ibex/endpoints/data.py
@@ -77,6 +77,7 @@ def field_value(
 def plot_data(
     uri: str,
     interpolate_over: Optional[List[str]] = Query(None),
+    interpolation_method: Optional[List[str]] = Query(None),
     downsampling_method: str | None = Query(None),
     downsampled_size: int = 1000,
 ) -> Any:
@@ -115,11 +116,18 @@ def plot_data(
 
     :param uri: IMAS URI with the path to leaf node
     :param interpolate_over: list of IMAS URIs used in interpolation. E.g. imas:hdf5?path=/home/ITER/wasikj/Desktop/work/IBEX/testdb2#equilibrium/time_slice[:]/profiles_2d[:]/psi
+    :param interpolation_method: method of interpolation; one of the possible parameters provided from /info/data_manipulation_methods
     :param downsampling_method: one of the downsampling metods returend by :func:`~ibex.endpoints.info.downsampling_methods` endpoint, or None
     :param downsampled_size: target size of downsampled data
     :rtype: dict (automatically converted to JSON by FastAPI)
     :return: JSON response
     """
     return CustomORJSONResponse(
-        ibex_service.get_plot_data(uri.strip(), interpolate_over, downsampling_method, downsampled_size)
+        ibex_service.get_plot_data(
+            uri=uri.strip(),
+            interpolate_over=interpolate_over,
+            interpolation_method=interpolation_method,
+            downsampling_method=downsampling_method,
+            downsampled_size=downsampled_size,
+        )
     )

--- a/backend/ibex/endpoints/data.py
+++ b/backend/ibex/endpoints/data.py
@@ -41,7 +41,6 @@ def field_value(
     uri: str,
     downsampling_method: str | None = Query(None),
     downsampled_size: int = 1000,
-    range: List[int] = Query(None),
 ) -> Any:
     """
     IBEX endpoint. Returns value extracted from pulsefile's leaf node.
@@ -58,7 +57,7 @@ def field_value(
     :return: JSON response
 
     """
-    return CustomORJSONResponse(ibex_service.get_data(uri.strip(), downsampling_method, downsampled_size, range))
+    return CustomORJSONResponse(ibex_service.get_data(uri.strip(), downsampling_method, downsampled_size))
 
 
 @router.get(

--- a/backend/ibex/endpoints/data.py
+++ b/backend/ibex/endpoints/data.py
@@ -77,7 +77,7 @@ def field_value(
 def plot_data(
     uri: str,
     interpolate_over: Optional[List[str]] = Query(None),
-    interpolation_method: Optional[List[str]] = Query(None),
+    interpolation_method: Optional[str] = Query(None),
     downsampling_method: str | None = Query(None),
     downsampled_size: int = 1000,
 ) -> Any:

--- a/backend/ibex/endpoints/info.py
+++ b/backend/ibex/endpoints/info.py
@@ -111,7 +111,7 @@ def data_manipulation_methods() -> dict:
                         "description": "Method used during data interpolation. All possible for scipy.interpolate.RegularGridInterpolator 'method' parameter or 'exact'",
                         "possible_values": [
                             {
-                                "value": "exact",
+                                "value": "exact_value",
                                 "description": "values are present only on data points where they were originally. Rest of the data grid is filled with NaNs",
                             },
                             {

--- a/backend/ibex/endpoints/info.py
+++ b/backend/ibex/endpoints/info.py
@@ -5,7 +5,11 @@ from fastapi import APIRouter  # type: ignore
 from ibex.core import ibex_service
 from ibex.core.utils import DownsamplingMethods
 from ibex import __version__
-from ibex.endpoints.schemas.info_schemas import VersionResponse, DownsamplingMethodsResponse
+from ibex.endpoints.schemas.info_schemas import (
+    VersionResponse,
+    DownsamplingMethodsResponse,
+    DataManipulationMethodsResponse,
+)
 
 router = APIRouter()
 
@@ -69,4 +73,75 @@ def downsampling_methods() -> dict:
 
     methods = [{"name": val.value["name"], "description": val.value["description"]} for val in DownsamplingMethods]
     res = {"downsampling_methods": methods}
+    return res
+
+
+@router.get(
+    "/info/data_manipulation_methods",
+    status_code=200,
+    response_model=DataManipulationMethodsResponse,
+    responses={
+        200: {"description": "Data manipulation methods returned successfully"},
+    },
+    description="Returns list of available data manipulation methods provided by the server",
+)
+@ibex_service.measure_execution_time
+def data_manipulation_methods() -> dict:
+    """
+    IBEX endpoint. Returns list of available data manipulation methods to be passed to /data/plot_data endpoint as query argument.
+
+    :rtype: dict (automatically converted to JSON by FastAPI)
+    :return: JSON response
+
+    """
+    res = {
+        "data_manipulation_methods": [
+            {
+                "name": "Data interpolation",
+                "description": "Operation performed in order to represent dataset over different set of coordinates",
+                "method_parameters": [
+                    {
+                        "human_readable_name": "Interpolate over",
+                        "name": "interpolate_over",
+                        "description": "List of URIs to gather coordinates from, for interpolation",
+                    },
+                    {
+                        "human_readable_name": "Data interpolation method",
+                        "name": "interpolation_method",
+                        "description": "Method used during data interpolation. All possible for scipy.interpolate.RegularGridInterpolator 'method' parameter or 'exact'",
+                        "possible_values": [
+                            {
+                                "value": "exact",
+                                "description": "values are present only on data points where they were originally. Rest of the data grid is filled with NaNs",
+                            },
+                            {
+                                "value": "linear",
+                                "description": "see scipy.interpolate.RegularGridInterpolator documentation",
+                            },
+                            {
+                                "value": "nearest",
+                                "description": "see scipy.interpolate.RegularGridInterpolator documentation",
+                            },
+                            {
+                                "value": "slinear",
+                                "description": "see scipy.interpolate.RegularGridInterpolator documentation",
+                            },
+                            {
+                                "value": "cubic",
+                                "description": "see scipy.interpolate.RegularGridInterpolator documentation",
+                            },
+                            {
+                                "value": "quintic",
+                                "description": "see scipy.interpolate.RegularGridInterpolator documentation",
+                            },
+                            {
+                                "value": "pchip",
+                                "description": "see scipy.interpolate.RegularGridInterpolator documentation",
+                            },
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
     return res

--- a/backend/ibex/endpoints/schemas/info_schemas.py
+++ b/backend/ibex/endpoints/schemas/info_schemas.py
@@ -20,3 +20,50 @@ class DownsamplingMethodsResponse(BaseModel):
     """Response for /info/downsampling_methods endpoint"""
 
     downsampling_methods: list[DownsamplingMethodModel] = Field(description="Available downsampling methods")
+
+
+# ========== DATA MANIPULATION METHODS ==========
+
+
+class DataManipulationMethodParameterPossibleValuesModel(BaseModel):
+    """Intermediate model for /info/data_manipulation_methods endpoint"""
+
+    value: str = Field(description="Possible value of parameter", examples=["linear", "nearest"])
+    description: str = Field(
+        description="Value description",
+        examples=[
+            "New point value will be interpolated using linear algorithm",
+            "New point value will be interpolated using nearest value",
+        ],
+    )
+
+
+class DataManipulationMethodParametersModel(BaseModel):
+    """Intermediate model for /info/data_manipulation_methods endpoint"""
+
+    human_readable_name: str = Field(
+        description="Human readable name of the parameter to be displayed in FE", examples=["Sigma", "Deviation level"]
+    )
+    name: str = Field(description="URL parameter name", examples=["sigma", "deviation_level"])
+    description: str = Field(description="Parameter description", examples=["Standard deviation for Gaussian kernel."])
+    possible_values: list[DataManipulationMethodParameterPossibleValuesModel] | None = Field(
+        default=None, description="Possible values for manipulation parameter"
+    )
+
+
+class DataManipulationMethodModel(BaseModel):
+    """Intermediate model for /info/data_manipulation_methods endpoint"""
+
+    name: str = Field(description="Method name", examples=["interpolation", "smoothing"])
+    description: str = Field(description="Method description", examples=["Gaussian smoothing"])
+    method_parameters: list[DataManipulationMethodParametersModel] = Field(
+        description="Parameters used in data manipulation method"
+    )
+
+
+class DataManipulationMethodsResponse(BaseModel):
+    """Response for /info/data_manipulation_methods endpoint"""
+
+    data_manipulation_methods: list[DataManipulationMethodModel] = Field(
+        description="Available data manipulation methods"
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,7 +16,7 @@ def interpolation_entry_path_directory(tmp_path_factory):
         eq = entry.factory.equilibrium()
 
         eq.ids_properties.homogeneous_time = 1
-        eq.time = np.asarray([1, 2, 3, 4])
+        eq.time = np.asarray([1, 2, 3, 4], dtype=float)
         eq.time_slice.resize(4)
         for ts in eq.time_slice:
             ts.profiles_2d.resize(2)
@@ -30,7 +30,7 @@ def interpolation_entry_path_directory(tmp_path_factory):
         eq = entry.factory.equilibrium()
 
         eq.ids_properties.homogeneous_time = 1
-        eq.time = np.asarray([1, 2, 3])
+        eq.time = np.asarray([1, 2, 3], dtype=float)
         eq.time_slice.resize(3)
         for ts in eq.time_slice:
             ts.profiles_2d.resize(4)

--- a/backend/tests/test_data_interpolation.py
+++ b/backend/tests/test_data_interpolation.py
@@ -6,23 +6,30 @@ from ibex.data_source.imas_python_source_utils import (
 )
 
 
-def test_simple_interpolation(interpolation_entry_path_directory):
-
+def test_interpolation_workflow(interpolation_entry_path_directory):
+    """
+    This function tests only returned data shape. It doesn't check values.
+    """
     db_names = [
         f"imas:hdf5?path={interpolation_entry_path_directory}/interpolation_db_1",
         f"imas:hdf5?path={interpolation_entry_path_directory}/interpolation_db_2",
     ]
     uri_fragment = "#equilibrium/time_slice[:]/profiles_2d[:]/psi"
     parameters = {"uri": f"{db_names[0]}/{uri_fragment}", "interpolate_over": [f"{db_names[1]}/{uri_fragment}"]}
+
+    for method in ["exact_value", "linear", "slinear", "nearest"]:
+        parameters["interpolation_method"] = method
+        response = pytest.test_client.get("/data/plot_data", params=parameters)
+        assert response.status_code == 200
+
+        json_data = response.json()["data"]
+        coords = json_data["coordinates"]
+        coord_shapes = [list(np.asarray(c["value"]).shape) for c in coords]
+        assert coord_shapes == [[4, 4, 12], [4, 4, 3], [4, 4], [4]]
+
+    parameters["interpolation_method"] = "non-existing-method"
     response = pytest.test_client.get("/data/plot_data", params=parameters)
-
-    assert response.status_code == 200
-
-    json_data = response.json()["data"]
-    coords = json_data["coordinates"]
-
-    coord_shapes = [list(np.asarray(c["value"]).shape) for c in coords]
-    assert coord_shapes == [[4, 4, 12], [4, 4, 3], [4, 4], [4]]
+    assert response.status_code == 466
 
 
 def test_resample_without_interpolation(interpolation_entry_path_directory):
@@ -44,7 +51,6 @@ def test_resample_without_interpolation(interpolation_entry_path_directory):
     assert coord_shapes == [[4, 4, 12], [4, 4, 3], [4, 4], [4]]
 
 
-@pytest.mark.skip()
 def test_resample_with_interpolation_function():
     # ================== 1D ==================
     data_1d = [1.0, 2.0, 3.0]

--- a/backend/tests/test_data_interpolation.py
+++ b/backend/tests/test_data_interpolation.py
@@ -1,5 +1,9 @@
 import numpy as np
 import pytest
+from ibex.data_source.imas_python_source_utils import (
+    resample_data_with_interpolation,
+    resample_data_without_interpolation,
+)
 
 
 def test_simple_interpolation(interpolation_entry_path_directory):
@@ -19,3 +23,85 @@ def test_simple_interpolation(interpolation_entry_path_directory):
 
     coord_shapes = [list(np.asarray(c["value"]).shape) for c in coords]
     assert coord_shapes == [[4, 4, 12], [4, 4, 3], [4, 4], [4]]
+
+
+def test_resample_without_interpolation(interpolation_entry_path_directory):
+
+    db_names = [
+        f"imas:hdf5?path={interpolation_entry_path_directory}/interpolation_db_1",
+        f"imas:hdf5?path={interpolation_entry_path_directory}/interpolation_db_2",
+    ]
+    uri_fragment = "#equilibrium/time_slice[:]/profiles_2d[:]/psi"
+    parameters = {"uri": f"{db_names[0]}/{uri_fragment}", "interpolate_over": [f"{db_names[1]}/{uri_fragment}"]}
+    response = pytest.test_client.get("/data/plot_data", params=parameters)
+
+    assert response.status_code == 200
+
+    json_data = response.json()["data"]
+    coords = json_data["coordinates"]
+
+    coord_shapes = [list(np.asarray(c["value"]).shape) for c in coords]
+    assert coord_shapes == [[4, 4, 12], [4, 4, 3], [4, 4], [4]]
+
+
+@pytest.mark.skip()
+def test_resample_with_interpolation_function():
+    # ================== 1D ==================
+    data_1d = [1.0, 2.0, 3.0]
+    coords_1d = [[0.0, 1.0, 2.0]]
+    target_coords_1d = [[0.0, 0.5, 1.0, 1.5, 2.0, 2.5]]
+    returned_data = resample_data_with_interpolation(
+        original_coords=coords_1d, data=data_1d, target_coords=target_coords_1d
+    )
+
+    expected_returned_data = [1.0, 1.5, 2.0, 2.5, 3.0, np.nan]
+    assert np.allclose(returned_data, expected_returned_data, equal_nan=True)
+
+    # ================== 2D ==================
+    data_2d = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+    coords_2d = [[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]
+    target_coords_2d = [[0.0, 0.5, 1.0, 1.5, 2.0, 2.5], [0.0, 0.5, 1.0, 1.5, 2.0, 2.5]]
+    returned_data = resample_data_with_interpolation(
+        original_coords=coords_2d, data=data_2d, target_coords=target_coords_2d
+    )
+
+    expected_returned_data = [
+        [1.0, 1.5, 2.0, 2.5, 3.0, np.nan],
+        [2.5, 3.0, 3.5, 4.0, 4.5, np.nan],
+        [4.0, 4.5, 5.0, 5.5, 6.0, np.nan],
+        [5.5, 6.0, 6.5, 7.0, 7.5, np.nan],
+        [7.0, 7.5, 8.0, 8.5, 9.0, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+    ]
+    assert np.allclose(returned_data, expected_returned_data, equal_nan=True)
+
+
+def test_resample_without_interpolation_function():
+
+    data_1d = [1.0, 2.0, 3.0]
+    coords_1d = [[0.0, 1.0, 2.0]]
+    target_coords_1d = [[0.0, 0.5, 1.0, 1.5, 2.0, 2.5]]
+    returned_data = resample_data_without_interpolation(
+        original_coords=coords_1d, data=data_1d, target_coords=target_coords_1d
+    )
+
+    expected_returned_data = [1.0, np.nan, 2.0, np.nan, 3.0, np.nan]
+    assert np.allclose(returned_data, expected_returned_data, equal_nan=True)
+
+    # ================== 2D ==================
+    data_2d = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+    coords_2d = [[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]
+    target_coords_2d = [[0.0, 0.5, 1.0, 1.5, 2.0, 2.5], [0.0, 0.5, 1.0, 1.5, 2.0, 2.5]]
+    returned_data = resample_data_without_interpolation(
+        original_coords=coords_2d, data=data_2d, target_coords=target_coords_2d
+    )
+
+    expected_returned_data = [
+        [1.0, np.nan, 2.0, np.nan, 3.0, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+        [4.0, np.nan, 5.0, np.nan, 6.0, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+        [7.0, np.nan, 8.0, np.nan, 9.0, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+    ]
+    assert np.allclose(returned_data, expected_returned_data, equal_nan=True)

--- a/docs/source/developers_manual/backend_development/data_interpolation.rst
+++ b/docs/source/developers_manual/backend_development/data_interpolation.rst
@@ -19,6 +19,21 @@ The IDS name and node path must be identical for all URIs participating in the i
 
 Failure to meet this requirement will prevent interpolation from being performed.
 
+Configuration
+--------------
+
+IBEX supports configurable interpolation behavior via the ``interpolation_method`` parameter of the ``/data/plot_data`` endpoint.
+
+By default, the ``exact_value`` method is used. In this mode, the interpolated dataset retains values only at the original data points, while the coordinate grid may be extended.
+No new values are computed between existing points.
+
+Other supported interpolation methods include ``linear``, ``nearest``, ``slinear``, ``cubic``, ``quintic``, and ``pchip``.
+These methods generate interpolated values across the full coordinate grid and follow the behavior described in the SciPy documentation for ``RegularGridInterpolator``.
+
+You can retrieve the full list of available interpolation methods by querying the ``/info/data_manipulation_methods`` endpoint.
+
+
+
 Implementation
 ---------------
 


### PR DESCRIPTION
- added ``interpolation_method`` parameter to plot_data
   possible values are:
   -- exact_value (don't create new values)
   -- “linear”, “nearest”, “slinear”, “cubic”, “quintic” and “pchip” (``method`` parameter from [RegularGridInterpolator](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html))
- added new endpoint ``info/data_manipulation_methods`` - returning list of possible data manipulations (to be updated with new functionalities) - acts as reference for FE with names, descriptions and parameters
- added more detailed tests for interpolation
- updated docs