### PR TITLE
Show only filled nodes in the data tree

### DIFF
--- a/frontend/src/renderer/types/nodes.ts
+++ b/frontend/src/renderer/types/nodes.ts
@@ -11,12 +11,14 @@ export type NodeInfoChildrenResponse = {
   name: string;
   ndim: number;
   type: NodeInfoTypeEnum;
+  has_data: boolean;
 };
 
 export type NodeInfoResponse = NodeInfoChildrenResponse & {
   shape: number[];
   coordinates: string[];
   children: NodeInfoChildrenResponse[];
+  has_data: boolean;
 };
 
 export type SearchNodeResponse = {

--- a/frontend/src/renderer/types/nodes.ts
+++ b/frontend/src/renderer/types/nodes.ts
@@ -11,14 +11,14 @@ export type NodeInfoChildrenResponse = {
   name: string;
   ndim: number;
   type: NodeInfoTypeEnum;
-  has_data: boolean;
+  has_data: boolean | null;
 };
 
 export type NodeInfoResponse = NodeInfoChildrenResponse & {
   shape: number[];
   coordinates: string[];
   children: NodeInfoChildrenResponse[];
-  has_data: boolean;
+  has_data: boolean | null;
 };
 
 export type SearchNodeResponse = {

--- a/frontend/src/renderer/utils/fetchData.ts
+++ b/frontend/src/renderer/utils/fetchData.ts
@@ -146,7 +146,7 @@ export const fetchNodeInfos = async (
   const nodeInfos = await fetchFromApi<NodeInfoResponse>(
     `/ids_info/node_info?uri=${encodeURIComponent(nodeUri)}&show_error_bars=${showErrorBars}`,
   );
-  nodeInfos.children = nodeInfos.children.filter((c) => c.has_data);
+  nodeInfos.children = nodeInfos.children.filter((c) => c.has_data !== false);
   return nodeInfos;
 };
 

--- a/frontend/src/renderer/utils/fetchData.ts
+++ b/frontend/src/renderer/utils/fetchData.ts
@@ -143,9 +143,11 @@ export const fetchNodeInfos = async (
   nodeUri: string,
   showErrorBars: boolean,
 ) => {
-  return fetchFromApi<NodeInfoResponse>(
+  const nodeInfos = await fetchFromApi<NodeInfoResponse>(
     `/ids_info/node_info?uri=${encodeURIComponent(nodeUri)}&show_error_bars=${showErrorBars}`,
   );
+  nodeInfos.children = nodeInfos.children.filter((c) => c.has_data);
+  return nodeInfos;
 };
 
 /**


### PR DESCRIPTION
This feature from FE allow to receive data provided by BE (attributes `has_data`) when fetching data from `ids_info/node_info`.

It also filter received nodes to only show them having data in the tree.