### PR TITLE
Prevent the display of y line at zero in 2D plots

### DIFF
--- a/frontend/src/renderer/components/plot/Heatmap2D.tsx
+++ b/frontend/src/renderer/components/plot/Heatmap2D.tsx
@@ -69,11 +69,13 @@ export const Heatmap2D = ({
       exponentformat: 'power',
       showexponent: 'all',
       separatethousands: true,
+      zeroline: false,
     },
     yaxis: {
       exponentformat: 'power',
       showexponent: 'all',
       separatethousands: true,
+      zeroline: false,
     },
     modebar: {
       orientation: 'v',


### PR DESCRIPTION
This feature prevent the display of y line at zero in 2D plots.