### PR TITLE
Fix draggable compatibility with node 22

### DIFF
--- a/frontend/webpack.renderer.config.ts
+++ b/frontend/webpack.renderer.config.ts
@@ -1,4 +1,5 @@
 import type { Configuration } from 'webpack';
+import webpack from 'webpack';
 
 import { rules } from './webpack.rules';
 import { plugins } from './webpack.plugins';
@@ -12,7 +13,12 @@ export const rendererConfig: Configuration = {
   module: {
     rules,
   },
-  plugins,
+  plugins: [
+    ...plugins,
+    new webpack.DefinePlugin({
+      'process.env.DRAGGABLE_DEBUG': JSON.stringify(false),
+    }),
+  ],
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css'],
   },


### PR DESCRIPTION
I have checked if the migration from nodejs 20 to 22 works.

The only bug was with the draggable library so I just fixed it in this PR.

Since all E2E tests pass, I confirm that IBEX should works properly with node 22.