### PR TITLE
Fix error #76

### DIFF
--- a/backend/ibex/data_source/imas_python_source.py
+++ b/backend/ibex/data_source/imas_python_source.py
@@ -51,6 +51,7 @@ from ibex.data_source.imas_python_source_utils import (
     apply_savgol_filter,
     apply_gaussian_filter,
     apply_simple_operations,
+    resolve_irregular_coordinate_data_shape,
 )
 from ibex.core.data_manipulation_methods import SmoothingMethod, InterpolationMethod
 from ibex.endpoints.schemas.request_data_schemas import PlotDataRequestModel
@@ -1127,10 +1128,29 @@ class IMASPythonSource(DataSourceInterface):
 
                 # =================== GATHER ALL COORDINATES ===================
                 original_coord_values = []
-                new_common_coords = coordinates_to_be_returned
-                for c in new_common_coords:
+
+                should_resample_data_onto_new_coordinates: bool = False
+
+                for c in coordinates_to_be_returned:
                     c["value"] = convert_to_lists(c["value"])
                     original_coord_values.append(sorted(set(flatten(c["value"]))))
+
+                    expected_flattened_shape = np.array(c["value"]).shape[-1]
+                    flattened_shape = np.array(original_coord_values[-1]).shape[-1]
+
+                    if expected_flattened_shape != flattened_shape:
+                        # If given coordinate is different across AoS indices, we cannot simply flatted coordinates list to 1D.
+                        should_resample_data_onto_new_coordinates = True
+
+                if should_resample_data_onto_new_coordinates:
+                    # Coordinates values are different across AoS indices
+                    # New data array has to be created with all data points
+                    data_to_be_returned = resolve_irregular_coordinate_data_shape(
+                        coordinates=list(reversed([c["value"] for c in coordinates_to_be_returned])),
+                        data=data_to_be_returned,
+                        target_coordinates=list(reversed(original_coord_values)),
+                    )
+
                 original_coord_values.reverse()
 
                 for _uri in plot_data_query.interpolate_over:
@@ -1164,7 +1184,7 @@ class IMASPythonSource(DataSourceInterface):
                         x["value"] = sorted(set(flatten(x["value"]) + flatten(convert_to_lists(y["value"]))))
 
                 # reverse coordinates list so it matches data dimensions
-                common_coords_values = [c["value"] for c in reversed(new_common_coords)]
+                common_coords_values = [c["value"] for c in reversed(coordinates_to_be_returned)]
                 # =================== INTERPOLATE ===================
 
                 # === make data vector rectangular ===

--- a/backend/ibex/data_source/imas_python_source_utils.py
+++ b/backend/ibex/data_source/imas_python_source_utils.py
@@ -374,7 +374,7 @@ def resample_data_with_interpolation(
     try:
         result = interpolator(points)
     except ValueError as e:
-        raise InvalidParametersException(f"Cannot interpolate data: {e}", code=464) from None
+        raise InvalidParametersException(f"Cannot interpolate data: {e}") from None
 
     # revert mesh shape
     result = result.reshape([len(c) for c in target_coords])

--- a/backend/ibex/data_source/imas_python_source_utils.py
+++ b/backend/ibex/data_source/imas_python_source_utils.py
@@ -16,19 +16,19 @@ def resolve_irregular_coordinate_data_shape(
     """
     Convert data with irregular (nD / time-varying) coordinate arrays into a regular NaN-padded grid.
 
-    Comment from developer:
-    IMAS stores some quantities (e.g. profiles_1d[:]/electrons/temperature) with a coordinate
-    (e.g. rho_tor_norm) that has a *different* 1D array per time slice, or is *n-dimensional*
-    (e.g. 2D psi on a poloidal grid).  The SciPy interpolators used downstream (e.g.
-    RegularGridInterpolator) require data arranged as a full rectangular grid where each axis
-    corresponds to one unique set of coordinate values.
+    IMAS stores some quantities (e.g. ``profiles_1d[:]/electrons/temperature``) with a
+    coordinate (e.g. ``rho_tor_norm``) that has a *different* 1D array per time slice,
+    or is *n-dimensional* (e.g. 2D psi on a poloidal grid).  The SciPy interpolators
+    used downstream (e.g. RegularGridInterpolator) require data arranged as a full
+    rectangular grid where each axis corresponds to one unique set of coordinate values.
 
     This function:
-    1. Flattens the nested data array into a list of (coordinate-tuple, value) points, respecting
-       which coordinate dimension varies along which nesting level.
-    2. Creates an empty dense grid on ``target_coordinates`` (filled with NaN).
-    3. Places each point into the correct grid cell by looking up its coordinate values in the
-       target-coordinate index dictionaries.
+
+    * flattens the nested data array into a list of (coordinate-tuple, value) points,
+      respecting which coordinate dimension varies along which nesting level.
+    * creates an empty dense grid on ``target_coordinates`` (filled with NaN).
+    * places each point into the correct grid cell by looking up its coordinate values
+      in the target-coordinate index dictionaries.
 
     Cells that have no corresponding point remain NaN, signalling "no data at that location".
 

--- a/backend/ibex/data_source/imas_python_source_utils.py
+++ b/backend/ibex/data_source/imas_python_source_utils.py
@@ -10,6 +10,94 @@ from ibex.data_source.exception import InvalidParametersException
 import operator as _op
 
 
+def resolve_irregular_coordinate_data_shape(
+    coordinates: list[list[int]], data: list, target_coordinates: list[list[int]]
+):
+    """
+    Convert data with irregular (nD / time-varying) coordinate arrays into a regular NaN-padded grid.
+
+    Comment from developer:
+    IMAS stores some quantities (e.g. profiles_1d[:]/electrons/temperature) with a coordinate
+    (e.g. rho_tor_norm) that has a *different* 1D array per time slice, or is *n-dimensional*
+    (e.g. 2D psi on a poloidal grid).  The SciPy interpolators used downstream (e.g.
+    RegularGridInterpolator) require data arranged as a full rectangular grid where each axis
+    corresponds to one unique set of coordinate values.
+
+    This function:
+    1. Flattens the nested data array into a list of (coordinate-tuple, value) points, respecting
+       which coordinate dimension varies along which nesting level.
+    2. Creates an empty dense grid on ``target_coordinates`` (filled with NaN).
+    3. Places each point into the correct grid cell by looking up its coordinate values in the
+       target-coordinate index dictionaries.
+
+    Cells that have no corresponding point remain NaN, signalling "no data at that location".
+
+    :param coordinates: List of coordinate arrays. Arrays can be 1+D
+    :param data: Nested list / array of data values. The nesting depth must equal the number
+        of dimensions implied by *coordinates*.
+    :param target_coordinates: List of 1D arrays defining the output grid axes.
+    :return: ndarray of shape ``(len(tc) for tc in target_coordinates)``, filled with NaN
+        except where a data point fell on a grid vertex.
+    """
+
+    def convert_data_to_points_grid(
+        coordinates: list,
+        data,
+        result=None,
+    ):
+        """
+        Recursively flatten a nested data array into a list of ((x, y, …), value) tuples.
+
+        The nesting depth of *data* matches the number of coordinate dimensions.
+        At each level we consume one element from the coordinate arrays — if a coordinate
+        is a 1D array of the same length as the current *data* level, we index it at the
+        current position *i* (it varies along this dimension); otherwise it is treated as
+        a constant along this dimension and passed through unchanged.
+
+        When we reach a scalar (leaf), we record the accumulated coordinate tuple and its
+        value.  These points are later placed into the target grid.
+
+        :param coordinates: Coordinate arrays at the current recursion level. Each element
+            is either a 1D array (indexed by *i* if its length matches *data*) or a scalar
+            (passed through unchanged).
+        :param data: Data at the current recursion level — a nested list, array, or scalar.
+        :param result: Accumulator list of ``(tuple, value)`` pairs. Passed by reference.
+        """
+        if result is None:
+            result = []
+
+        if isinstance(data, (list, IDSNumericArray, np.ndarray)):
+            for i in range(len(data)):
+                new_coords = [
+                    c[i] if isinstance(c, (list, np.ndarray)) and len(c) > 0 and len(c) == len(data) else c
+                    for c in coordinates
+                ]
+                convert_data_to_points_grid(
+                    new_coords,
+                    data[i],
+                    result,
+                )
+        else:
+            result.append((tuple(coordinates), data))
+
+    # CONVERT DATA ARRAY INTO LIST OF POINTS
+    # single point = ((x, y, z, ...), value)
+    data_points = []
+    convert_data_to_points_grid(coordinates, data, result=data_points)
+
+    # FILL GRID FROM COLLECTED POINTS
+    output_shape = [len(tc) for tc in target_coordinates]
+    result = np.full(output_shape, np.nan, dtype=float)
+
+    lookups = [{val: idx for idx, val in enumerate(tc)} for tc in target_coordinates]
+
+    for position, value in data_points:
+        idx = tuple(lookups[d][position[d]] for d in range(len(position)))
+        result[idx] = value
+
+    return result
+
+
 def path_in_filled_paths(node_path: str, filled_paths: List[str]):
     """
     Returns true if node path is in filled paths.
@@ -283,7 +371,10 @@ def resample_data_with_interpolation(
     mesh = np.meshgrid(*target_coords, indexing="ij")
     points = np.stack(mesh, axis=-1).reshape(-1, len(target_coords))
 
-    result = interpolator(points)
+    try:
+        result = interpolator(points)
+    except ValueError as e:
+        raise InvalidParametersException(f"Cannot interpolate data: {e}", code=464) from None
 
     # revert mesh shape
     result = result.reshape([len(c) for c in target_coords])

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -34,6 +34,32 @@ def interpolation_entry_path_directory(tmp_path_factory):
                 p2d.grid.dim2 = np.asarray([1.0, 2.0, 3.0], dtype=float)
         entry.put(eq)
 
+        cp = entry.factory.core_profiles()
+        cp.ids_properties.homogeneous_time = 1
+        cp.time = np.array([1.0, 2.0, 3.0, 4.0])
+        cp.profiles_1d.resize(4)
+
+        for i, p1d in enumerate(cp.profiles_1d):
+            n_rho = 10
+            p1d.grid.rho_tor_norm = np.linspace(0.1 + i * 0.01, 1.0 + i * 0.01, n_rho)
+            p1d.electrons.temperature = np.linspace(1000 - i * 100, 100 + i * 10, n_rho)
+
+        cp.profiles_2d.resize(4)
+        for j, p2d in enumerate(cp.profiles_2d):
+            p2d.ion.resize(2)
+            for k, ion in enumerate(p2d.ion):
+                ion.temperature = np.array(
+                    [
+                        [j + k + 1.0, j + k + 2.0, j + k + 3.0],
+                        [j + k + 4.0, j + k + 5.0, j + k + 6.0],
+                        [j + k + 7.0, j + k + 8.0, j + k + 9.0],
+                    ],
+                    dtype=float,
+                )
+            p2d.grid.dim1 = np.array([0.0, 1.0, 2.0], dtype=float)
+            p2d.grid.dim2 = np.array([0.0, 1.0, 2.0], dtype=float)
+        entry.put(cp)
+
     with imas.DBEntry(f"imas:hdf5?path={tmp_path}/interpolation_db_2", mode="w") as entry:
         eq = entry.factory.equilibrium()
 
@@ -55,6 +81,33 @@ def interpolation_entry_path_directory(tmp_path_factory):
                 p2d.grid.dim1 = np.asarray([0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.1, 2.4, 2.7], dtype=float)
                 p2d.grid.dim2 = np.asarray([1.0, 2.0, 3.0], dtype=float)
         entry.put(eq)
+
+        cp = entry.factory.core_profiles()
+        cp.ids_properties.homogeneous_time = 1
+        cp.time = np.array([1.5, 2.5, 3.5])
+        cp.profiles_1d.resize(3)
+
+        for i, p1d in enumerate(cp.profiles_1d):
+            n_rho = 8
+            p1d.grid.rho_tor_norm = np.linspace(0.2 + i * 0.02, 1.0 + i * 0.02, n_rho)
+            p1d.electrons.temperature = np.linspace(900 - i * 50, 200 + i * 20, n_rho)
+
+        cp.profiles_2d.resize(3)
+        for j, p2d in enumerate(cp.profiles_2d):
+            p2d.ion.resize(2)
+            for k, ion in enumerate(p2d.ion):
+                ion.temperature = np.array(
+                    [
+                        [j + k + 10.0, j + k + 11.0, j + k + 12.0],
+                        [j + k + 13.0, j + k + 14.0, j + k + 15.0],
+                        [j + k + 16.0, j + k + 17.0, j + k + 18.0],
+                    ],
+                    dtype=float,
+                )
+            p2d.grid.dim1 = np.array([0.0, 1.0, 2.0], dtype=float)
+            p2d.grid.dim2 = np.array([0.0, 1.0, 2.0], dtype=float)
+        entry.put(cp)
+
     return tmp_path
 
 

--- a/backend/tests/test_interpolation_irregular_coordinates.py
+++ b/backend/tests/test_interpolation_irregular_coordinates.py
@@ -1,0 +1,38 @@
+import pytest
+
+
+def test_interpolation_irregular_coordinate(interpolation_entry_path_directory):
+    db_names = [
+        f"imas:hdf5?path={interpolation_entry_path_directory}/interpolation_db_1",
+        f"imas:hdf5?path={interpolation_entry_path_directory}/interpolation_db_2",
+    ]
+    uri_fragment = "#core_profiles:0/profiles_1d[:]/electrons/temperature"
+    parameters = {
+        "uri": f"{db_names[0]}/{uri_fragment}",
+        "interpolate_over": [f"{db_names[1]}/{uri_fragment}"],
+    }
+
+    for method in ["exact_value", "linear", "slinear", "nearest"]:
+        parameters["interpolation_method"] = method
+        response = pytest.test_client.get("/data/plot_data", params=parameters)
+
+        if method == "slinear":
+            assert response.status_code == 464
+        else:
+            assert response.status_code == 200
+
+
+def test_plot_data_profiles_2d(interpolation_entry_path_directory):
+    db_names = [
+        f"imas:hdf5?path={interpolation_entry_path_directory}/interpolation_db_1",
+        f"imas:hdf5?path={interpolation_entry_path_directory}/interpolation_db_2",
+    ]
+    uri_fragment = "#core_profiles:0/profiles_2d[:]/ion[:]/temperature"
+    parameters = {
+        "uri": f"{db_names[0]}/{uri_fragment}",
+        "interpolate_over": [f"{db_names[1]}/{uri_fragment}"],
+        "interpolation_method": "exact_value",  # non time-based AoS are supported only by `exact_value` method
+    }
+
+    response = pytest.test_client.get("/data/plot_data", params=parameters)
+    assert response.status_code == 200

--- a/backend/tests/test_interpolation_irregular_coordinates.py
+++ b/backend/tests/test_interpolation_irregular_coordinates.py
@@ -17,7 +17,7 @@ def test_interpolation_irregular_coordinate(interpolation_entry_path_directory):
         response = pytest.test_client.get("/data/plot_data", params=parameters)
 
         if method == "slinear":
-            assert response.status_code == 464
+            assert response.status_code == 466
         else:
             assert response.status_code == 200
 


### PR DESCRIPTION
If flattened coordinate doesn't match data shape, data array is being extrapolated to new coordinates.

For instance:
```
#core_profiles/time = [1,2]
#core_profiles/profiles_1d <- size 2
#core_profiles/profiles_1d[0]/electrons/temperature = [1,2,3]
#core_profiles/profiles_1d[1]/electrons/temperature = [4,5,6]
#core_profiles/profiles_1d[0]/grid/rho_tor_norm = [1,2,3]
#core_profiles/profiles_1d[1]/grid/rho_tor_norm = [4,5,6]

Flattened time is [1,2]
Flattened rho_tor_norm is [1,2,3,4,5,6]
!Data is [[1,2,3],[4,5,6]] -> shape = (2,3), expected (2,6)

^^^ this data<>coordinates set cannot be represented as regular 2D matrix, because value of rho_tor_norm depends on time (one coordinate depends on another)

in this case we convert data to 2D, filling empty points with Nan:

             time
           0       1
rho=1      1       Nan
rho=2      2       Nan
rho=3      3       Nan
rho=4      Nan     4
rho=5      Nan     5
rho=6      Nan     6
```

This does't work for `slinear` interpolation, because it doesn't support `NaN`s in data:
```
ValueError: Array must not contain infs or nans.
```